### PR TITLE
Add weighted projections

### DIFF
--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -312,6 +312,8 @@ class CartesianCoordinateHandler(CoordinateHandler):
                             chunk[field].in_units(ounits),
                             bnds, kernel_name="cubic",
                             weight_field=chunk[weight].in_units(wounits))
+                    mylog.info("Making a fixed resolution buffer of (%s) %d by %d" % \
+                                (weight, size[0], size[1]))
                     for chunk in proj_reg.chunks([], 'io'):
                         data_source._initialize_projected_units([weight], chunk)
                         pixelize_sph_kernel_projection(

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -120,7 +120,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
              ("index", "cell_volume")])
 
     def pixelize(self, dimension, data_source, field, bounds, size,
-                 antialias = True, periodic = True):
+                 antialias = True, periodic = True, weight_field = None):
         """
         Method for pixelizing datasets in preparation for
         two-dimensional image plots. Relies on several sampling
@@ -175,7 +175,8 @@ class CartesianCoordinateHandler(CoordinateHandler):
 
         elif self.axis_id.get(dimension, dimension) < 3:
             return self._ortho_pixelize(data_source, field, bounds, size,
-                                        antialias, dimension, periodic)
+                                        antialias, dimension, periodic, 
+                                        weight_field)
         else:
             return self._oblique_pixelize(data_source, field, bounds, size,
                                           antialias)
@@ -232,7 +233,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
 
 
     def _ortho_pixelize(self, data_source, field, bounds, size, antialias,
-                        dim, periodic):
+                        dim, periodic, weight_field=None):
         from yt.frontends.sph.data_structures import ParticleDataset
         from yt.frontends.stream.data_structures import StreamParticlesDataset
         from yt.data_objects.selection_data_containers import \
@@ -292,6 +293,21 @@ class CartesianCoordinateHandler(CoordinateHandler):
                         chunk[ptype, 'density'].in_units('g/cm**3'),
                         chunk[field].in_units(ounits),
                         bnds)
+                if weight_field is not None:
+                    weight_buff = np.zeros(size, dtype='float64')
+                    wounits = data_source.ds.field_info[weight_field].output_units
+                    for chunk in proj_reg.chunks([], 'io'):
+                        data_source._initialize_projected_units([weight_field], chunk)
+                        pixelize_sph_kernel_projection(
+                            weight_buff,
+                            chunk[ptype, px_name].in_units('cm'),
+                            chunk[ptype, py_name].in_units('cm'),
+                            chunk[ptype, 'smoothing_length'].in_units('cm'),
+                            chunk[ptype, 'particle_mass'].in_units('g'),
+                            chunk[ptype, 'density'].in_units('g/cm**3'),
+                            chunk[weight_field].in_units(ounits),
+                            bnds)
+                    buff /= weight_buff
             elif isinstance(data_source, YTSlice):
                 buff = np.zeros(size, dtype='float64')
                 for chunk in data_source.chunks([], 'io'):

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -268,6 +268,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
             px_name = 'particle_position_%s' % self.axis_name[self.x_axis[dim]]
             py_name = 'particle_position_%s' % self.axis_name[self.y_axis[dim]]
             if isinstance(data_source, YTKDTreeProj):
+                weight = data_source.weight_field
                 le = data_source.data_source.left_edge.in_units('code_length')
                 re = data_source.data_source.right_edge.in_units('code_length')
                 le[self.x_axis[dim]] = bounds[0]
@@ -281,21 +282,36 @@ class CartesianCoordinateHandler(CoordinateHandler):
                 bnds = data_source.ds.arr(
                     bounds, 'code_length').in_units('cm').tolist()
                 buff = np.zeros(size, dtype='float64')
-                for chunk in proj_reg.chunks([], 'io'):
-                    data_source._initialize_projected_units([field], chunk)
-                    pixelize_sph_kernel_projection(
-                        buff,
-                        chunk[ptype, px_name].in_units('cm'),
-                        chunk[ptype, py_name].in_units('cm'),
-                        chunk[ptype, 'smoothing_length'].in_units('cm'),
-                        chunk[ptype, 'particle_mass'].in_units('g'),
-                        chunk[ptype, 'density'].in_units('g/cm**3'),
-                        chunk[field].in_units(ounits),
-                        bnds)
-                if data_source.weight_field is not None:
-                    weight = data_source.weight_field
+                if weight is None:
+                    for chunk in proj_reg.chunks([], 'io'):
+                        data_source._initialize_projected_units([field], chunk)
+                        pixelize_sph_kernel_projection(
+                            buff,
+                            chunk[ptype, px_name].in_units('cm'),
+                            chunk[ptype, py_name].in_units('cm'),
+                            chunk[ptype, 'smoothing_length'].in_units('cm'),
+                            chunk[ptype, 'particle_mass'].in_units('g'),
+                            chunk[ptype, 'density'].in_units('g/cm**3'),
+                            chunk[field].in_units(ounits),
+                            bnds)
+                # if there is a weight field, take two projections:
+                # one of field*weight, the other of just weight, and divide them
+                else:
                     weight_buff = np.zeros(size, dtype='float64')
                     wounits = data_source.ds.field_info[weight].output_units
+                    for chunk in proj_reg.chunks([], 'io'):
+                        data_source._initialize_projected_units([field], chunk)
+                        data_source._initialize_projected_units([weight], chunk)
+                        pixelize_sph_kernel_projection(
+                            buff,
+                            chunk[ptype, px_name].in_units('cm'),
+                            chunk[ptype, py_name].in_units('cm'),
+                            chunk[ptype, 'smoothing_length'].in_units('cm'),
+                            chunk[ptype, 'particle_mass'].in_units('g'),
+                            chunk[ptype, 'density'].in_units('g/cm**3'),
+                            chunk[field].in_units(ounits),
+                            bnds, kernel_name="cubic",
+                            weight_field=chunk[weight].in_units(wounits))
                     for chunk in proj_reg.chunks([], 'io'):
                         data_source._initialize_projected_units([weight], chunk)
                         pixelize_sph_kernel_projection(
@@ -305,7 +321,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
                             chunk[ptype, 'smoothing_length'].in_units('cm'),
                             chunk[ptype, 'particle_mass'].in_units('g'),
                             chunk[ptype, 'density'].in_units('g/cm**3'),
-                            chunk[weight].in_units(ounits),
+                            chunk[weight].in_units(wounits),
                             bnds)
                     buff /= weight_buff
             elif isinstance(data_source, YTSlice):

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -963,7 +963,8 @@ def pixelize_sph_kernel_projection(
         np.float64_t[:] pdens,
         np.float64_t[:] quantity_to_smooth,
         bounds,
-        kernel_name="cubic"):
+        kernel_name="cubic",
+        weight_field=None):
 
     cdef np.intp_t xsize, ysize
     cdef np.float64_t x_min, x_max, y_min, y_max, w_j, coeff
@@ -971,6 +972,10 @@ def pixelize_sph_kernel_projection(
     cdef np.float64_t qxy2, posx_diff, posy_diff, ih_j2
     cdef np.float64_t x, y, dx, dy, idx, idy, h_j2
     cdef int index, i, j
+    cdef np.float64_t[:] _weight_field
+
+    if weight_field is not None:
+        _weight_field = weight_field
 
     xsize, ysize = buff.shape[0], buff.shape[1]
 
@@ -1007,7 +1012,10 @@ def pixelize_sph_kernel_projection(
             ih_j2 = 1.0/h_j2
             
             w_j = pmass[j] / pdens[j] / hsml[j]**3
-            coeff = w_j * hsml[j] * quantity_to_smooth[j]
+            if weight_field is None:
+                coeff = w_j * hsml[j] * quantity_to_smooth[j]
+            else:
+                coeff = w_j * hsml[j] * quantity_to_smooth[j] * _weight_field[j]
 
             # Now we know which pixels to deposit onto for this particle,
             # so loop over them and add this particle's contribution


### PR DESCRIPTION
## PR Summary

This adds the functionality of generating weighted projections for particle-based datasets in the demeshening.  It resolves [Issue #1715](https://github.com/yt-project/yt/issues/1715)

![snapshot_600_projection_x_density](https://user-images.githubusercontent.com/8250999/39024704-78a7df76-43f7-11e8-96df-cf253f8d165f.png)
![snapshot_600_projection_x_temperature_density](https://user-images.githubusercontent.com/8250999/39024705-78c37e16-43f7-11e8-976c-8f5074fc22b3.png)
