### PR TITLE
Fix a Gadget particle counting bug

### DIFF
--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -81,7 +81,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
     def _yield_coordinates(self, data_file, needed_ptype=None):
         si, ei = data_file.start, data_file.end
         f = h5py.File(data_file.filename)
-        pcount = f["/Header"].attrs["NumPart_ThisFile"][:]
+        pcount = f["/Header"].attrs["NumPart_ThisFile"][:].astype("int")
         np.clip(pcount - si, 0, ei - si, out=pcount)
         pcount = pcount.sum()
         for key in f.keys():
@@ -103,7 +103,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
         ind = int(ptype[-1])
         si, ei = data_file.start, data_file.end
         with h5py.File(data_file.filename) as f:
-            pcount = int(f["/Header"].attrs["NumPart_ThisFile"][ind])
+            pcount = f["/Header"].attrs["NumPart_ThisFile"][ind].astype("int")
             pcount = np.clip(pcount - si, 0, ei - si)
             ds = f[ptype]["SmoothingLength"][si:ei,...]
             dt = ds.dtype.newbyteorder("N") # Native
@@ -166,7 +166,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
     def _count_particles(self, data_file):
         si, ei = data_file.start, data_file.end
         f = h5py.File(data_file.filename, "r")
-        pcount = f["/Header"].attrs["NumPart_ThisFile"][:]
+        pcount = f["/Header"].attrs["NumPart_ThisFile"][:].astype("int")
         f.close()
         if None not in (si, ei):
             np.clip(pcount - si, 0, ei - si, out=pcount)


### PR DESCRIPTION
Ensure `pcount`'s `dtype` is `int` instead of `uint`. Otherwise, later in `np.clip`, `pcount - si` could be positive when it's supposed to be negative, resulting in the wrong answer.

In most Gadget snapshot, `"NumPart_ThisFile"` is actually saved as `int`. But I would think it also reasonable to save it as `uint`. When this parameter is read into yt, it becomes `uint`. I encountered this bug when I was trying to write a snapshot using yt parameters and read it back. Since it's now saved as `uint`, the bug is triggered.