### PR TITLE
Metal density

### DIFF
--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -130,3 +130,12 @@ class GizmoFieldInfo(GadgetFieldInfo):
                     "smoothing_length", "density", field,
                     self, num_neighbors)
                 self.alias(("gas", field), (ptype, field))
+
+        def _metal_density_field(field, data):
+            return data[ptype, "metallicity"] * data[ptype, "density"]
+        self.add_field((ptype, "metal_density"),
+                       #sampling_type="particle",
+                       sampling_type="local",
+                       function=_metal_density_field,
+                       units=self.ds.unit_system["density"])
+        self.alias(("gas", "metal_density"), (ptype, "metal_density"))

--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -134,7 +134,6 @@ class GizmoFieldInfo(GadgetFieldInfo):
         def _metal_density_field(field, data):
             return data[ptype, "metallicity"] * data[ptype, "density"]
         self.add_field((ptype, "metal_density"),
-                       #sampling_type="particle",
                        sampling_type="local",
                        function=_metal_density_field,
                        units=self.ds.unit_system["density"])


### PR DESCRIPTION
Create a metal density field for gizmo frontend in sph-viz.  This metal density field is same as the metal density field for other frontends in that it is the mass density of the total metals in each gas parcel.  

I'm not sure how to manage PRs to sph-viz of this kind.  Submitting this PR to sph-viz repo since that is where I actually need it, rather than submitting a slightly different PR to main yt repo, then waiting for it to merge and then having to tweak that to PR it to sph-viz.  If a different workflow is suggested for code contributions like this, I'm open to changing.